### PR TITLE
Updated Readme.md with corrected example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Article article;
 
 try
 {
-  article = await reader.Read("http://frontendplay.com/story/4/http-caching-demystified-part-2-implementation");
+  article = await reader.Read(new Uri("http://frontendplay.com/story/4/http-caching-demystified-part-2-implementation"));
 }
 catch (Exception exc)
 {


### PR DESCRIPTION
The .Read method cannot be called with a string, only a Uri, so the example code was changed to reflect this.
