### PR TITLE
added a way to inject additional article hints into ReadSharp

### DIFF
--- a/ReadSharp/Models/TranscoderOptions.cs
+++ b/ReadSharp/Models/TranscoderOptions.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace ReadSharp.Models
+{
+    public class TranscoderOptions
+    {
+        /// <summary>
+        /// A dictionary of url matching regex as key to html element selector as value that represents hints for the transcoder to be able to find the actual article content within downlaoded HTML
+        /// </summary>
+        public IDictionary<Regex, string> ArticleElementHints { get; set; }
+
+        public TranscoderOptions()
+        {
+            ArticleElementHints = new Dictionary<Regex, string>();
+        }
+    }
+}

--- a/ReadSharp/ReadSharp.csproj
+++ b/ReadSharp/ReadSharp.csproj
@@ -86,6 +86,7 @@
     <Compile Include="Models\ArticleImage.cs" />
     <Compile Include="Models\HttpOptions.cs" />
     <Compile Include="Models\ReadOptions.cs" />
+    <Compile Include="Models\TranscoderOptions.cs" />
     <Compile Include="Reader.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Models\Response.cs" />

--- a/ReadSharp/Reader.cs
+++ b/ReadSharp/Reader.cs
@@ -10,6 +10,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
+using ReadSharp.Models;
 
 
 namespace ReadSharp
@@ -63,25 +64,22 @@ namespace ReadSharp
     /// Initializes a new instance of the <see cref="Reader" /> class.
     /// </summary>
     /// <param name="options">The HTTP options.</param>
-    public Reader(HttpOptions options = null)
-    {
-      // initialize transcoder
-      _transcoder = new NReadabilityTranscoder(
-        dontStripUnlikelys: false,
-        dontNormalizeSpacesInTextContent: true,
-        dontWeightClasses: false,
-        readingStyle: ReadingStyle.Ebook,
-        readingMargin: ReadingMargin.Narrow,
-        readingSize: ReadingSize.Medium
-      );
-
-      // get default HTTP options if none available
+    public Reader(HttpOptions options = null, TranscoderOptions transcoderOptions = null)
+    {      
+        // get default HTTP options if none available
       if (options == null)
       {
         options = HttpOptions.CreateDefault();
       }
 
+        if (transcoderOptions == null)
+        {
+            transcoderOptions = new TranscoderOptions();
+        }
+
       _options = options;
+
+      _transcoder = CreateTranscoder(transcoderOptions);
 
       // initialize custom encoder
       _encoder = new Encodings.Encoder(true);
@@ -113,8 +111,7 @@ namespace ReadSharp
     }
 
 
-
-    /// <summary>
+      /// <summary>
     /// Reads article content from the given URI.
     /// </summary>
     /// <param name="uri">An URI to extract the content from.</param>
@@ -245,7 +242,18 @@ namespace ReadSharp
       return _transcoder.Transcode(transcodingInput);
     }
 
-
+      private static NReadabilityTranscoder CreateTranscoder(TranscoderOptions transcoderOptions)
+      {
+          return new NReadabilityTranscoder(
+              dontStripUnlikelys: false,
+              dontNormalizeSpacesInTextContent: true,
+              dontWeightClasses: false,
+              readingStyle: ReadingStyle.Ebook,
+              readingMargin: ReadingMargin.Narrow,
+              readingSize: ReadingSize.Medium,
+              articleElementHints: transcoderOptions.ArticleElementHints
+              );
+      }
 
     /// <summary>
     /// Reverses the deep links.


### PR DESCRIPTION
NReadability has some hard coded settings for being able to extract content from specific sites where automatic extraction fails. They do this by having a dictionary of site url -> html element selector containing the content of the article.

Unfortunately they do not list all possible sites that have this problem and there is no way to inject additional sites. This changeset allows one to optionally pass the same url -> selector dictionary down to nreadability to be added to their hardcoded list. Also adds slashdot to the hardcoded list while we're at it :)
